### PR TITLE
Replace deprecated schema() with model_json_schema()

### DIFF
--- a/demo/main.py
+++ b/demo/main.py
@@ -460,12 +460,12 @@ class App:
         # route to setup frontend
         @self.app.get("/api/settings")
         async def settings():
-            info_schema = self.pipeline.Info.schema()
+            info_schema = self.pipeline.Info.model_json_schema()
             info = self.pipeline.Info()
             if info.page_content:
                 page_content = markdown2.markdown(info.page_content)
 
-            input_params = self.pipeline.InputParams.schema()
+            input_params = self.pipeline.InputParams.model_json_schema()
             return JSONResponse(
                 {
                     "info": info_schema,


### PR DESCRIPTION
Fix #31

Replace the deprecated `BaseModel.schema()` calls in `demo/main.py` with
`model_json_schema()` (available since pydantic 2.0.0, identical output),
removing the `PydanticDeprecatedSince20` warning emitted on every
`/api/settings` request.